### PR TITLE
Allow "." as the notification root name

### DIFF
--- a/ProjectedFSLib.Managed.API/NotificationMapping.h
+++ b/ProjectedFSLib.Managed.API/NotificationMapping.h
@@ -94,7 +94,7 @@ namespace ProjFS {
         /// <param name="notificationMask">The set of notifications that ProjFS should return for the
         /// virtualization root specified in <paramref name="notificationRoot"/>.</param>
         /// <param name="notificationRoot">The path to the notification root, relative to the virtualization
-        /// root.</param>
+        /// root.  The virtualization root itself must be specified as an empty string.</param>
         NotificationMapping(NotificationType notificationMask, System::String^ notificationRoot);
 
         /// <summary>
@@ -111,7 +111,8 @@ namespace ProjFS {
         }
 
         /// <summary>
-        /// A path to a directory, relative to the virtualization root.
+        /// A path to a directory, relative to the virtualization root.  The virtualization root itself
+        /// must be specified as an empty string.
         /// </summary>
         /// <value>
         /// ProjFS will send to the provider the notifications specified in <see cref="NotificationMask"/>
@@ -138,6 +139,12 @@ namespace ProjFS {
         : notificationMask(notificationMask)
         , notificationRoot(notificationRoot)
     {
+        // The underlying native API expects that the virtualization root is specified as an empty
+        // string.  If the caller provides ".", convert that to the correct form.
+        if (notificationRoot->Equals("."))
+        {
+            notificationRoot = "";
+        }
     }
 
     inline NotificationType NotificationMapping::NotificationMask::get(void)
@@ -157,6 +164,13 @@ namespace ProjFS {
 
     inline void NotificationMapping::NotificationRoot::set(System::String^ root)
     {
+        // The underlying native API expects that the virtualization root is specified as an empty
+        // string.  If the caller provides ".", convert that to the correct form.
+        if (root->Equals("."))
+        {
+            root = "";
+        }
+
         this->notificationRoot = root;
     }
 }}} // namespace Microsoft.Windows.ProjFS

--- a/ProjectedFSLib.Managed.API/NotificationMapping.h
+++ b/ProjectedFSLib.Managed.API/NotificationMapping.h
@@ -94,7 +94,7 @@ namespace ProjFS {
         /// <param name="notificationMask">The set of notifications that ProjFS should return for the
         /// virtualization root specified in <paramref name="notificationRoot"/>.</param>
         /// <param name="notificationRoot">The path to the notification root, relative to the virtualization
-        /// root.  The virtualization root itself must be specified as an empty string.</param>
+        /// root.</param>
         NotificationMapping(NotificationType notificationMask, System::String^ notificationRoot);
 
         /// <summary>
@@ -111,8 +111,7 @@ namespace ProjFS {
         }
 
         /// <summary>
-        /// A path to a directory, relative to the virtualization root.  The virtualization root itself
-        /// must be specified as an empty string.
+        /// A path to a directory, relative to the virtualization root.
         /// </summary>
         /// <value>
         /// ProjFS will send to the provider the notifications specified in <see cref="NotificationMask"/>

--- a/ProjectedFSLib.Managed.Test/BasicTests.cs
+++ b/ProjectedFSLib.Managed.Test/BasicTests.cs
@@ -38,11 +38,6 @@ namespace ProjectedFSLib.Managed.Test
             helpers = new Helpers(10 * 1000);
         }
 
-        // We start the virtualization instance in the SetUp fixture, so that exercises the following
-        // methods in Microsoft.Windows.ProjFS:
-        //  VirtualizationInstance.VirtualizationInstance()
-        //  VirtualizationInstance.MarkDirectoryAsVirtualizationRoot()
-        //  VirtualizationInstance.StartVirtualizing()
         [SetUp]
         public void TestSetup()
         {
@@ -50,7 +45,8 @@ namespace ProjectedFSLib.Managed.Test
                 out string sourceRoot,
                 out string virtRoot);
 
-            helpers.StartTestProvider(sourceRoot, virtRoot);
+            // We defer starting the provider to the test case so that it can specify extra options
+            // if it wants to.
         }
 
         // We stop the virtualization instance in the TearDown fixture, so that exercises the following
@@ -94,6 +90,12 @@ namespace ProjectedFSLib.Managed.Test
             helpers.StopTestProvider();
         }
 
+        // We start the virtualization instance in each test case, so that exercises the following
+        // methods in Microsoft.Windows.ProjFS:
+        //  VirtualizationInstance.VirtualizationInstance()
+        //  VirtualizationInstance.MarkDirectoryAsVirtualizationRoot()
+        //  VirtualizationInstance.StartVirtualizing()
+
         // This case exercises the following methods in Microsoft.Windows.ProjFS:
         //  VirtualizationInstance.WritePlaceholderInfo()
         //  VirtualizationInstance.CreateWriteBuffer()
@@ -106,7 +108,7 @@ namespace ProjectedFSLib.Managed.Test
         [TestCase("dir1\\dir2\\dir3\\bar.txt")]
         public void TestCanReadThroughVirtualizationRoot(string destinationFile)
         {
-            helpers.GetRootNamesForTest(out string sourceRoot, out string virtRoot);
+            helpers.StartTestProvider(out string sourceRoot, out string virtRoot);
 
             // Some contents to write to the file in the source and read out through the virtualization.
             string fileContent = nameof(TestCanReadThroughVirtualizationRoot);
@@ -131,7 +133,7 @@ namespace ProjectedFSLib.Managed.Test
         [Test]
         public void TestEnumerationInVirtualizationRoot()
         {
-            helpers.GetRootNamesForTest(out string sourceRoot, out string virtRoot);
+            helpers.StartTestProvider(out string sourceRoot, out string virtRoot);
 
             Random random = new Random();
 
@@ -219,9 +221,12 @@ namespace ProjectedFSLib.Managed.Test
             }
         }
 
-        [Test]
-        public void TestNotificationFileOpened()
+        [TestCase(true)]
+        [TestCase(false)]
+        public void TestNotificationFileOpened(bool useDotAsRootName)
         {
+            helpers.StartTestProvider(useDotAsRootName);
+
             string fileName = "file.txt";
 
             // Create the virtual file.
@@ -236,9 +241,12 @@ namespace ProjectedFSLib.Managed.Test
             Assert.That(helpers.NotificationEvents[(int)Helpers.NotifyWaitHandleNames.FileHandleClosedNoModification].WaitOne(helpers.WaitTimeoutInMs));
         }
 
-        [Test]
-        public void TestNotificationNewFileCreated()
+        [TestCase(true)]
+        [TestCase(false)]
+        public void TestNotificationNewFileCreated(bool useDotAsRootName)
         {
+            helpers.StartTestProvider(useDotAsRootName);
+
             string fileName = "newfile.txt";
 
             // Create a new file in the virtualization root.
@@ -248,9 +256,12 @@ namespace ProjectedFSLib.Managed.Test
             Assert.That(helpers.NotificationEvents[(int)Helpers.NotifyWaitHandleNames.NewFileCreated].WaitOne(helpers.WaitTimeoutInMs));
         }
 
-        [Test]
-        public void TestNotificationFileOverwritten()
+        [TestCase(true)]
+        [TestCase(false)]
+        public void TestNotificationFileOverwritten(bool useDotAsRootName)
         {
+            helpers.StartTestProvider(useDotAsRootName);
+
             string fileName = "overwriteme.txt";
 
             // Create a virtual file.
@@ -265,9 +276,12 @@ namespace ProjectedFSLib.Managed.Test
             Assert.That(helpers.NotificationEvents[(int)Helpers.NotifyWaitHandleNames.FileOverwritten].WaitOne(helpers.WaitTimeoutInMs));
         }
 
-        [Test]
-        public void TestNotificationDelete()
+        [TestCase(true)]
+        [TestCase(false)]
+        public void TestNotificationDelete(bool useDotAsRootName)
         {
+            helpers.StartTestProvider(useDotAsRootName);
+
             string fileName = "deleteme.txt";
 
             // Create a virtual file.
@@ -283,9 +297,12 @@ namespace ProjectedFSLib.Managed.Test
             Assert.That(helpers.NotificationEvents[(int)Helpers.NotifyWaitHandleNames.FileHandleClosedFileModifiedOrDeleted].WaitOne(helpers.WaitTimeoutInMs));
         }
 
-        [Test]
-        public void TestNotificationRename()
+        [TestCase(true)]
+        [TestCase(false)]
+        public void TestNotificationRename(bool useDotAsRootName)
         {
+            helpers.StartTestProvider(useDotAsRootName);
+
             string fileName = "OldName.txt";
 
             // Create a virtual file.
@@ -309,9 +326,12 @@ namespace ProjectedFSLib.Managed.Test
           IntPtr lpSecurityAttributes
           );
 
-        [Test]
-        public void TestNotificationHardLink()
+        [TestCase(true)]
+        [TestCase(false)]
+        public void TestNotificationHardLink(bool useDotAsRootName)
         {
+            helpers.StartTestProvider(useDotAsRootName);
+
             string fileName = "linkTarget.txt";
 
             // Create a virtual file.
@@ -329,9 +349,12 @@ namespace ProjectedFSLib.Managed.Test
             Assert.That(helpers.NotificationEvents[(int)Helpers.NotifyWaitHandleNames.HardlinkCreated].WaitOne(helpers.WaitTimeoutInMs));
         }
 
-        [Test]
-        public void TestConvertToFull()
+        [TestCase(true)]
+        [TestCase(false)]
+        public void TestConvertToFull(bool useDotAsRootName)
         {
+            helpers.StartTestProvider(useDotAsRootName);
+
             string fileName = "fileToWriteTo.txt";
 
             // Create a virtual file.

--- a/ProjectedFSLib.Managed.Test/BasicTests.cs
+++ b/ProjectedFSLib.Managed.Test/BasicTests.cs
@@ -11,6 +11,21 @@ using System.Threading;
 
 namespace ProjectedFSLib.Managed.Test
 {
+    public class DataSources
+    {
+        public static object[] AllBools
+        {
+            get
+            {
+                return new object[]
+                {
+                     new object[] { true },
+                     new object[] { false },
+                };
+            }
+        }
+    }
+
     // Set of basic tests to exercise the entry points in the managed code API wrapper.
     //
     // The Microsoft.Windows.ProjFS managed API is a fairly thin wrapper around a set of native
@@ -221,8 +236,7 @@ namespace ProjectedFSLib.Managed.Test
             }
         }
 
-        [TestCase(true)]
-        [TestCase(false)]
+        [TestCaseSource(typeof(DataSources), nameof(DataSources.AllBools))]
         public void TestNotificationFileOpened(bool useDotAsRootName)
         {
             helpers.StartTestProvider(useDotAsRootName);
@@ -241,8 +255,7 @@ namespace ProjectedFSLib.Managed.Test
             Assert.That(helpers.NotificationEvents[(int)Helpers.NotifyWaitHandleNames.FileHandleClosedNoModification].WaitOne(helpers.WaitTimeoutInMs));
         }
 
-        [TestCase(true)]
-        [TestCase(false)]
+        [TestCaseSource(typeof(DataSources), nameof(DataSources.AllBools))]
         public void TestNotificationNewFileCreated(bool useDotAsRootName)
         {
             helpers.StartTestProvider(useDotAsRootName);
@@ -256,8 +269,7 @@ namespace ProjectedFSLib.Managed.Test
             Assert.That(helpers.NotificationEvents[(int)Helpers.NotifyWaitHandleNames.NewFileCreated].WaitOne(helpers.WaitTimeoutInMs));
         }
 
-        [TestCase(true)]
-        [TestCase(false)]
+        [TestCaseSource(typeof(DataSources), nameof(DataSources.AllBools))]
         public void TestNotificationFileOverwritten(bool useDotAsRootName)
         {
             helpers.StartTestProvider(useDotAsRootName);
@@ -276,8 +288,7 @@ namespace ProjectedFSLib.Managed.Test
             Assert.That(helpers.NotificationEvents[(int)Helpers.NotifyWaitHandleNames.FileOverwritten].WaitOne(helpers.WaitTimeoutInMs));
         }
 
-        [TestCase(true)]
-        [TestCase(false)]
+        [TestCaseSource(typeof(DataSources), nameof(DataSources.AllBools))]
         public void TestNotificationDelete(bool useDotAsRootName)
         {
             helpers.StartTestProvider(useDotAsRootName);
@@ -297,8 +308,7 @@ namespace ProjectedFSLib.Managed.Test
             Assert.That(helpers.NotificationEvents[(int)Helpers.NotifyWaitHandleNames.FileHandleClosedFileModifiedOrDeleted].WaitOne(helpers.WaitTimeoutInMs));
         }
 
-        [TestCase(true)]
-        [TestCase(false)]
+        [TestCaseSource(typeof(DataSources), nameof(DataSources.AllBools))]
         public void TestNotificationRename(bool useDotAsRootName)
         {
             helpers.StartTestProvider(useDotAsRootName);
@@ -326,8 +336,7 @@ namespace ProjectedFSLib.Managed.Test
           IntPtr lpSecurityAttributes
           );
 
-        [TestCase(true)]
-        [TestCase(false)]
+        [TestCaseSource(typeof(DataSources), nameof(DataSources.AllBools))]
         public void TestNotificationHardLink(bool useDotAsRootName)
         {
             helpers.StartTestProvider(useDotAsRootName);
@@ -349,8 +358,7 @@ namespace ProjectedFSLib.Managed.Test
             Assert.That(helpers.NotificationEvents[(int)Helpers.NotifyWaitHandleNames.HardlinkCreated].WaitOne(helpers.WaitTimeoutInMs));
         }
 
-        [TestCase(true)]
-        [TestCase(false)]
+        [TestCaseSource(typeof(DataSources), nameof(DataSources.AllBools))]
         public void TestConvertToFull(bool useDotAsRootName)
         {
             helpers.StartTestProvider(useDotAsRootName);

--- a/ProjectedFSLib.Managed.Test/Helpers.cs
+++ b/ProjectedFSLib.Managed.Test/Helpers.cs
@@ -51,8 +51,20 @@ namespace ProjectedFSLib.Managed.Test
             }
         }
 
-        public void StartTestProvider(string sourceRoot, string virtRoot)
+        public void StartTestProvider()
         {
+            StartTestProvider(out string sourceRoot, out string virtRoot);
+        }
+
+        public void StartTestProvider(bool useDotAsRootName)
+        {
+            StartTestProvider(out string sourceRoot, out string virtRoot, useDotAsRootName);
+        }
+
+        public void StartTestProvider(out string sourceRoot, out string virtRoot, bool useDotAsRootName = false)
+        {
+            GetRootNamesForTest(out sourceRoot, out virtRoot);
+
             // Get the provider name from the command line.
             var providerExe = TestContext.Parameters.Get("ProviderExe");
 
@@ -66,7 +78,13 @@ namespace ProjectedFSLib.Managed.Test
             string sourceArg = " --sourceroot " + sourceRoot;
             string virtRootArg = " --virtroot " + virtRoot;
 
-            // Add the source and virtRoot arguments, as well as the "test mode" argument.
+            string useDot = string.Empty;
+            if (useDotAsRootName)
+            {
+                useDot = " -u ";
+            }
+
+            // Add all the arguments, as well as the "test mode" argument.
             ProviderProcess.StartInfo.Arguments = sourceArg + virtRootArg + " -t";
             ProviderProcess.StartInfo.UseShellExecute = true;
 

--- a/simpleProviderManaged/ProviderOptions.cs
+++ b/simpleProviderManaged/ProviderOptions.cs
@@ -24,6 +24,9 @@ namespace SimpleProviderManaged
         [Option('d', "denyDeletes", HelpText = "Deny deletes.", Hidden = true)]
         public bool DenyDeletes { get; set; }
 
+        [Option('u', "useDotAsRootName", HelpText = "Set up notifications using . as root name instead of empty string.", Hidden = true)]
+        public bool UseDotAsRootname { get; set; }
+
         [Usage(ApplicationAlias = "SimpleProviderManaged")]
         public static IEnumerable<Example> Examples
         {

--- a/simpleProviderManaged/SimpleProvider.cs
+++ b/simpleProviderManaged/SimpleProvider.cs
@@ -46,6 +46,12 @@ namespace SimpleProviderManaged
             List<NotificationMapping> notificationMappings;
             if (this.Options.EnableNotifications)
             {
+                string rootName = string.Empty;
+                if (this.Options.UseDotAsRootname)
+                {
+                    rootName = ".";
+                }
+
                 notificationMappings = new List<NotificationMapping>()
                 {
                     new NotificationMapping(
@@ -61,7 +67,7 @@ namespace SimpleProviderManaged
                         | NotificationType.FileHandleClosedFileModified
                         | NotificationType.FileHandleClosedFileDeleted
                         | NotificationType.FilePreConvertToFull,
-                        string.Empty)
+                        rootName)
                 };
             }
             else


### PR DESCRIPTION
Fixes issue #20 

This modifies `NotificationMapping` to convert `.` to `string.Empty` to accommodate providers that might think `.` is valid syntax for the virtualization root.

Added test cases w/ supporting modifications to `SimpleProviderManaged`.