### PR TITLE
Don't allow "." as a notification root

### DIFF
--- a/ProjectedFSLib.Managed.API/DirectoryEnumerationResults.h
+++ b/ProjectedFSLib.Managed.API/DirectoryEnumerationResults.h
@@ -52,7 +52,7 @@ public:
     ///     the entry it was trying to add when it got <c>false</c>. 
     ///     </para>
     ///     <para>
-    ///     If the function returns <c>false</c> for the first file or directory in the enumeration, the
+    ///     If the method returns <c>false</c> for the first file or directory in the enumeration, the
     ///     provider returns <see cref="HResult::InsufficientBuffer"/> from the <c>GetDirectoryEnumerationCallback</c>
     ///     method.
     ///     </para>
@@ -109,7 +109,7 @@ public:
     ///     the entry it was trying to add when it got <c>false</c>. 
     ///     </para>
     ///     <para>
-    ///     If the function returns <c>false</c> for the first file or directory in the enumeration, the
+    ///     If the method returns <c>false</c> for the first file or directory in the enumeration, the
     ///     provider returns <see cref="HResult::InsufficientBuffer"/> from the <c>GetDirectoryEnumerationCallback</c>
     ///     method.
     ///     </para>

--- a/ProjectedFSLib.Managed.API/NotificationMapping.h
+++ b/ProjectedFSLib.Managed.API/NotificationMapping.h
@@ -94,7 +94,12 @@ namespace ProjFS {
         /// <param name="notificationMask">The set of notifications that ProjFS should return for the
         /// virtualization root specified in <paramref name="notificationRoot"/>.</param>
         /// <param name="notificationRoot">The path to the notification root, relative to the virtualization
-        /// root.</param>
+        /// root.  The virtualization root itself must be specified as an empty string.</param>
+        /// <exception cref="System::ArgumentException">
+        /// <paramref name="notificationRoot"/> begins with <c>.</c>.  <paramref name="notificationRoot"/>
+        /// must be specified relative to the virtualization root, with the virtualization root itself
+        /// specified as an empty string.
+        /// </exception>
         NotificationMapping(NotificationType notificationMask, System::String^ notificationRoot);
 
         /// <summary>
@@ -111,12 +116,18 @@ namespace ProjFS {
         }
 
         /// <summary>
-        /// A path to a directory, relative to the virtualization root.
+        /// A path to a directory, relative to the virtualization root.  The virtualization root itself
+        /// must be specified as an empty string.
         /// </summary>
         /// <value>
         /// ProjFS will send to the provider the notifications specified in <see cref="NotificationMask"/>
         /// for this directory and its descendants.
         /// </value>
+        /// <exception cref="System::ArgumentException">
+        /// The notification root value begins with <c>.</c>.  The notification root must be specified
+        /// relative to the virtualization root, with the virtualization root itself specified as an
+        /// empty string.
+        /// </exception>
         property System::String^ NotificationRoot
         {
             System::String^ get(void);
@@ -138,11 +149,10 @@ namespace ProjFS {
         : notificationMask(notificationMask)
         , notificationRoot(notificationRoot)
     {
-        // The underlying native API expects that the virtualization root is specified as an empty
-        // string.  If the caller provides ".", convert that to the correct form.
-        if (notificationRoot->Equals("."))
+        if (notificationRoot->StartsWith("."))
         {
-            notificationRoot = "";
+            throw gcnew System::ArgumentException(System::String::Format(System::Globalization::CultureInfo::InvariantCulture,
+                                                                         "notificationRoot cannot begin with \".\""));
         }
     }
 
@@ -163,13 +173,11 @@ namespace ProjFS {
 
     inline void NotificationMapping::NotificationRoot::set(System::String^ root)
     {
-        // The underlying native API expects that the virtualization root is specified as an empty
-        // string.  If the caller provides ".", convert that to the correct form.
-        if (root->Equals("."))
+        if (root->StartsWith("."))
         {
-            root = "";
+            throw gcnew System::ArgumentException(System::String::Format(System::Globalization::CultureInfo::InvariantCulture,
+                                                                         "The notification root path cannot begin with \".\""));
         }
-
         this->notificationRoot = root;
     }
 }}} // namespace Microsoft.Windows.ProjFS

--- a/ProjectedFSLib.Managed.API/NotificationMapping.h
+++ b/ProjectedFSLib.Managed.API/NotificationMapping.h
@@ -149,10 +149,11 @@ namespace ProjFS {
         : notificationMask(notificationMask)
         , notificationRoot(notificationRoot)
     {
-        if (notificationRoot->StartsWith("."))
+        if ((notificationRoot == ".") ||
+            notificationRoot->StartsWith(".\\"))
         {
             throw gcnew System::ArgumentException(System::String::Format(System::Globalization::CultureInfo::InvariantCulture,
-                                                                         "notificationRoot cannot begin with \".\""));
+                                                                         "notificationRoot cannot be \".\" or begin with \".\\\""));
         }
     }
 
@@ -173,10 +174,11 @@ namespace ProjFS {
 
     inline void NotificationMapping::NotificationRoot::set(System::String^ root)
     {
-        if (root->StartsWith("."))
+        if ((root == ".") ||
+            root->StartsWith(".\\"))
         {
             throw gcnew System::ArgumentException(System::String::Format(System::Globalization::CultureInfo::InvariantCulture,
-                                                                         "The notification root path cannot begin with \".\""));
+                                                                         "The notification root path cannot be \".\" or begin with \".\\\""));
         }
         this->notificationRoot = root;
     }

--- a/ProjectedFSLib.Managed.API/NotificationMapping.h
+++ b/ProjectedFSLib.Managed.API/NotificationMapping.h
@@ -96,7 +96,7 @@ namespace ProjFS {
         /// <param name="notificationRoot">The path to the notification root, relative to the virtualization
         /// root.  The virtualization root itself must be specified as an empty string.</param>
         /// <exception cref="System::ArgumentException">
-        /// <paramref name="notificationRoot"/> begins with <c>.</c>.  <paramref name="notificationRoot"/>
+        /// <paramref name="notificationRoot"/> is <c>.</c> or begins with <c>.\</c>.  <paramref name="notificationRoot"/>
         /// must be specified relative to the virtualization root, with the virtualization root itself
         /// specified as an empty string.
         /// </exception>
@@ -124,9 +124,9 @@ namespace ProjFS {
         /// for this directory and its descendants.
         /// </value>
         /// <exception cref="System::ArgumentException">
-        /// The notification root value begins with <c>.</c>.  The notification root must be specified
-        /// relative to the virtualization root, with the virtualization root itself specified as an
-        /// empty string.
+        /// The notification root value is <c>.</c> or begins with <c>.\</c>.  The notification root
+        /// must be specified relative to the virtualization root, with the virtualization root itself
+        /// specified as an empty string.
         /// </exception>
         property System::String^ NotificationRoot
         {

--- a/ProjectedFSLib.Managed.Test/BasicTests.cs
+++ b/ProjectedFSLib.Managed.Test/BasicTests.cs
@@ -11,21 +11,6 @@ using System.Threading;
 
 namespace ProjectedFSLib.Managed.Test
 {
-    public class DataSources
-    {
-        public static object[] AllBools
-        {
-            get
-            {
-                return new object[]
-                {
-                     new object[] { true },
-                     new object[] { false },
-                };
-            }
-        }
-    }
-
     // Set of basic tests to exercise the entry points in the managed code API wrapper.
     //
     // The Microsoft.Windows.ProjFS managed API is a fairly thin wrapper around a set of native
@@ -236,10 +221,10 @@ namespace ProjectedFSLib.Managed.Test
             }
         }
 
-        [TestCaseSource(typeof(DataSources), nameof(DataSources.AllBools))]
-        public void TestNotificationFileOpened(bool useDotAsRootName)
+        [Test]
+        public void TestNotificationFileOpened()
         {
-            helpers.StartTestProvider(useDotAsRootName);
+            helpers.StartTestProvider();
 
             string fileName = "file.txt";
 
@@ -255,10 +240,10 @@ namespace ProjectedFSLib.Managed.Test
             Assert.That(helpers.NotificationEvents[(int)Helpers.NotifyWaitHandleNames.FileHandleClosedNoModification].WaitOne(helpers.WaitTimeoutInMs));
         }
 
-        [TestCaseSource(typeof(DataSources), nameof(DataSources.AllBools))]
-        public void TestNotificationNewFileCreated(bool useDotAsRootName)
+        [Test]
+        public void TestNotificationNewFileCreated()
         {
-            helpers.StartTestProvider(useDotAsRootName);
+            helpers.StartTestProvider();
 
             string fileName = "newfile.txt";
 
@@ -269,10 +254,10 @@ namespace ProjectedFSLib.Managed.Test
             Assert.That(helpers.NotificationEvents[(int)Helpers.NotifyWaitHandleNames.NewFileCreated].WaitOne(helpers.WaitTimeoutInMs));
         }
 
-        [TestCaseSource(typeof(DataSources), nameof(DataSources.AllBools))]
-        public void TestNotificationFileOverwritten(bool useDotAsRootName)
+        [Test]
+        public void TestNotificationFileOverwritten()
         {
-            helpers.StartTestProvider(useDotAsRootName);
+            helpers.StartTestProvider();
 
             string fileName = "overwriteme.txt";
 
@@ -288,10 +273,10 @@ namespace ProjectedFSLib.Managed.Test
             Assert.That(helpers.NotificationEvents[(int)Helpers.NotifyWaitHandleNames.FileOverwritten].WaitOne(helpers.WaitTimeoutInMs));
         }
 
-        [TestCaseSource(typeof(DataSources), nameof(DataSources.AllBools))]
-        public void TestNotificationDelete(bool useDotAsRootName)
+        [Test]
+        public void TestNotificationDelete()
         {
-            helpers.StartTestProvider(useDotAsRootName);
+            helpers.StartTestProvider();
 
             string fileName = "deleteme.txt";
 
@@ -308,10 +293,10 @@ namespace ProjectedFSLib.Managed.Test
             Assert.That(helpers.NotificationEvents[(int)Helpers.NotifyWaitHandleNames.FileHandleClosedFileModifiedOrDeleted].WaitOne(helpers.WaitTimeoutInMs));
         }
 
-        [TestCaseSource(typeof(DataSources), nameof(DataSources.AllBools))]
-        public void TestNotificationRename(bool useDotAsRootName)
+        [Test]
+        public void TestNotificationRename()
         {
-            helpers.StartTestProvider(useDotAsRootName);
+            helpers.StartTestProvider();
 
             string fileName = "OldName.txt";
 
@@ -336,10 +321,10 @@ namespace ProjectedFSLib.Managed.Test
           IntPtr lpSecurityAttributes
           );
 
-        [TestCaseSource(typeof(DataSources), nameof(DataSources.AllBools))]
-        public void TestNotificationHardLink(bool useDotAsRootName)
+        [Test]
+        public void TestNotificationHardLink()
         {
-            helpers.StartTestProvider(useDotAsRootName);
+            helpers.StartTestProvider();
 
             string fileName = "linkTarget.txt";
 
@@ -358,10 +343,10 @@ namespace ProjectedFSLib.Managed.Test
             Assert.That(helpers.NotificationEvents[(int)Helpers.NotifyWaitHandleNames.HardlinkCreated].WaitOne(helpers.WaitTimeoutInMs));
         }
 
-        [TestCaseSource(typeof(DataSources), nameof(DataSources.AllBools))]
-        public void TestConvertToFull(bool useDotAsRootName)
+        [Test]
+        public void TestConvertToFull()
         {
-            helpers.StartTestProvider(useDotAsRootName);
+            helpers.StartTestProvider();
 
             string fileName = "fileToWriteTo.txt";
 

--- a/ProjectedFSLib.Managed.Test/Helpers.cs
+++ b/ProjectedFSLib.Managed.Test/Helpers.cs
@@ -56,12 +56,7 @@ namespace ProjectedFSLib.Managed.Test
             StartTestProvider(out string sourceRoot, out string virtRoot);
         }
 
-        public void StartTestProvider(bool useDotAsRootName)
-        {
-            StartTestProvider(out string sourceRoot, out string virtRoot, useDotAsRootName);
-        }
-
-        public void StartTestProvider(out string sourceRoot, out string virtRoot, bool useDotAsRootName = false)
+        public void StartTestProvider(out string sourceRoot, out string virtRoot)
         {
             GetRootNamesForTest(out sourceRoot, out virtRoot);
 
@@ -77,12 +72,6 @@ namespace ProjectedFSLib.Managed.Test
 
             string sourceArg = " --sourceroot " + sourceRoot;
             string virtRootArg = " --virtroot " + virtRoot;
-
-            string useDot = string.Empty;
-            if (useDotAsRootName)
-            {
-                useDot = " -u ";
-            }
 
             // Add all the arguments, as well as the "test mode" argument.
             ProviderProcess.StartInfo.Arguments = sourceArg + virtRootArg + " -t";

--- a/simpleProviderManaged/ProviderOptions.cs
+++ b/simpleProviderManaged/ProviderOptions.cs
@@ -24,9 +24,6 @@ namespace SimpleProviderManaged
         [Option('d', "denyDeletes", HelpText = "Deny deletes.", Hidden = true)]
         public bool DenyDeletes { get; set; }
 
-        [Option('u', "useDotAsRootName", HelpText = "Set up notifications using . as root name instead of empty string.", Hidden = true)]
-        public bool UseDotAsRootname { get; set; }
-
         [Usage(ApplicationAlias = "SimpleProviderManaged")]
         public static IEnumerable<Example> Examples
         {

--- a/simpleProviderManaged/SimpleProvider.cs
+++ b/simpleProviderManaged/SimpleProvider.cs
@@ -47,11 +47,6 @@ namespace SimpleProviderManaged
             if (this.Options.EnableNotifications)
             {
                 string rootName = string.Empty;
-                if (this.Options.UseDotAsRootname)
-                {
-                    rootName = ".";
-                }
-
                 notificationMappings = new List<NotificationMapping>()
                 {
                     new NotificationMapping(


### PR DESCRIPTION
When registering for notifications a provider must specify the virtualization root as an empty string when registering for notifications that span the entire virtualization root.  Previously if a provider specified `.` as a notification root there was no error and the provider would not get the notifications it expected.

fixes #20 