### PR TITLE
Update Win10 SDK to 18362

### DIFF
--- a/scripts/BuildProjFS-Managed.bat
+++ b/scripts/BuildProjFS-Managed.bat
@@ -24,7 +24,7 @@ SET vswhere=%PROJFS_PACKAGESDIR%\vswhere.%vswherever%\tools\vswhere.exe
 
 :: Use vswhere to find the latest VS installation (including prerelease installations) with the msbuild component.
 :: See https://github.com/Microsoft/vswhere/wiki/Find-MSBuild
-for /f "usebackq tokens=*" %%i in (`%vswhere% -all -prerelease -latest -version "[15.0,17.0)" -products * -requires Microsoft.Component.MSBuild Microsoft.VisualStudio.Workload.ManagedDesktop Microsoft.VisualStudio.Workload.NativeDesktop Microsoft.VisualStudio.Workload.NetCoreTools Microsoft.VisualStudio.Component.Windows10SDK.17763 Microsoft.VisualStudio.Component.VC.CLI.Support -property installationPath`) do (
+for /f "usebackq tokens=*" %%i in (`%vswhere% -all -prerelease -latest -version "[15.0,17.0)" -products * -requires Microsoft.Component.MSBuild Microsoft.VisualStudio.Workload.ManagedDesktop Microsoft.VisualStudio.Workload.NativeDesktop Microsoft.VisualStudio.Workload.NetCoreTools Microsoft.VisualStudio.Component.Windows10SDK.18362 Microsoft.VisualStudio.Component.VC.CLI.Support -property installationPath`) do (
   set VsInstallDir=%%i
 )
 


### PR DESCRIPTION
The VS2019 installs on the pipeline image no longer have the version of the SDK that our build script looks for.  Updating the build script to a later SDK version.