### PR TITLE
Update build script and targeting nugets to allow the project to build on the windows-2022 image

### DIFF
--- a/ProjectedFSLib.Managed.API/NetFramework/ProjectedFSLib.Managed.vcxproj
+++ b/ProjectedFSLib.Managed.API/NetFramework/ProjectedFSLib.Managed.vcxproj
@@ -27,4 +27,14 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
   </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <Import Project="..\..\..\packages\Microsoft.NETFramework.ReferenceAssemblies.net461.1.0.2\build\Microsoft.NETFramework.ReferenceAssemblies.net461.targets" Condition="Exists('..\..\..\packages\Microsoft.NETFramework.ReferenceAssemblies.net461.1.0.2\build\Microsoft.NETFramework.ReferenceAssemblies.net461.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\..\..\packages\Microsoft.NETFramework.ReferenceAssemblies.net461.1.0.2\build\Microsoft.NETFramework.ReferenceAssemblies.net461.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\Microsoft.NETFramework.ReferenceAssemblies.net461.1.0.2\build\Microsoft.NETFramework.ReferenceAssemblies.net461.targets'))" />
+  </Target>
 </Project>

--- a/ProjectedFSLib.Managed.API/NetFramework/ProjectedFSLib.Managed.vcxproj.filters
+++ b/ProjectedFSLib.Managed.API/NetFramework/ProjectedFSLib.Managed.vcxproj.filters
@@ -110,5 +110,6 @@
     <None Include="..\scripts\CreateVersionHeader.bat">
       <Filter>Source Files</Filter>
     </None>
+    <None Include="packages.config" />
   </ItemGroup>
 </Project>

--- a/ProjectedFSLib.Managed.API/NetFramework/packages.config
+++ b/ProjectedFSLib.Managed.API/NetFramework/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microsoft.NETFramework.ReferenceAssemblies.net461" version="1.0.2" targetFramework="native" developmentDependency="true" />
+</packages>

--- a/ProjectedFSLib.Managed.API/ProjectedFSLib.Managed.props
+++ b/ProjectedFSLib.Managed.API/ProjectedFSLib.Managed.props
@@ -48,14 +48,14 @@
     <CodeAnalysisRuleSet>MixedRecommendedRules.ruleset</CodeAnalysisRuleSet>
     <RunCodeAnalysis>true</RunCodeAnalysis>
     <TargetName>ProjectedFSLib.Managed</TargetName>
-    <IncludePath>C:\Program Files (x86)\Windows Kits\10\Include\10.0.18362\um;$(IncludePath)</IncludePath>
+    <IncludePath>C:\Program Files (x86)\Windows Kits\10\Include\10.0.19041\um;$(IncludePath)</IncludePath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <LinkIncremental>false</LinkIncremental>
     <CodeAnalysisRuleSet>MixedRecommendedRules.ruleset</CodeAnalysisRuleSet>
     <RunCodeAnalysis>false</RunCodeAnalysis>
     <TargetName>ProjectedFSLib.Managed</TargetName>
-    <IncludePath>C:\Program Files (x86)\Windows Kits\10\Include\10.0.18362.0\um;$(IncludePath)</IncludePath>
+    <IncludePath>C:\Program Files (x86)\Windows Kits\10\Include\10.0.19041.0\um;$(IncludePath)</IncludePath>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
@@ -65,11 +65,11 @@
       <WarningLevel>Level4</WarningLevel>
       <TreatWarningAsError>true</TreatWarningAsError>
       <EnablePREfast>true</EnablePREfast>
-      <AdditionalIncludeDirectories>C:\Program Files (x86)\Windows Kits\10\Include\10.0.18362.0\um;$(BuildOutputDir)\$(ProjectName);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>C:\Program Files (x86)\Windows Kits\10\Include\10.0.19041.0\um;$(BuildOutputDir)\$(ProjectName);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <AdditionalDependencies>ProjectedFSLib.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalLibraryDirectories>C:\Program Files (x86)\Windows Kits\10\Lib\10.0.18362.0\um\x64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>C:\Program Files (x86)\Windows Kits\10\Lib\10.0.19041.0\um\x64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
     <PreBuildEvent>
       <Command>$(ProjectDir)\..\Scripts\CreateVersionHeader.bat $(ProjectName) $(ProjFSManagedVersion) $(SolutionDir) &amp;&amp; $(ProjectDir)\..\Scripts\CreateCliAssemblyVersion.bat $(ProjectName) $(ProjFSManagedVersion) $(SolutionDir)</Command>
@@ -87,11 +87,11 @@
       <TreatWarningAsError>true</TreatWarningAsError>
       <EnablePREfast>false</EnablePREfast>
       <GenerateXMLDocumentationFiles>true</GenerateXMLDocumentationFiles>
-      <AdditionalIncludeDirectories>C:\Program Files (x86)\Windows Kits\10\Include\10.0.18362.0\um;$(BuildOutputDir)\$(ProjectName);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>C:\Program Files (x86)\Windows Kits\10\Include\10.0.19041.0\um;$(BuildOutputDir)\$(ProjectName);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <AdditionalDependencies>ProjectedFSLib.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalLibraryDirectories>C:\Program Files (x86)\Windows Kits\10\Lib\10.0.18362.0\um\x64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>C:\Program Files (x86)\Windows Kits\10\Lib\10.0.19041.0\um\x64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
     <PreBuildEvent>
       <Command>$(ProjectDir)\..\Scripts\CreateVersionHeader.bat $(ProjectName) $(ProjFSManagedVersion) $(SolutionDir) &amp;&amp; $(ProjectDir)\..\Scripts\CreateCliAssemblyVersion.bat $(ProjectName) $(ProjFSManagedVersion) $(SolutionDir)</Command>

--- a/ProjectedFSLib.Managed.Test/ProjectedFSLib.Managed.Test.csproj
+++ b/ProjectedFSLib.Managed.Test/ProjectedFSLib.Managed.Test.csproj
@@ -12,6 +12,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
     <PackageReference Include="NUnitLite" Version="3.11.0" />
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net461" Version="1.0.2" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 |Branch|Functional Tests|
 |:--:|:--:|
-|**main**|[![Build status](https://dev.azure.com/projfs/ci/_apis/build/status/PR%20-%20Build%20and%20Functional%20Test%20-%202019?branchName=main)](https://dev.azure.com/projfs/ci/_build/latest?definitionId=5)|
-|**release**|[![Build status](https://dev.azure.com/microsoft/OS/_apis/build/status/ProjFS%20CI%20-%20Build,%20Sign,%20Package)](https://dev.azure.com/microsoft/OS/_build/latest?definitionId=37476)|
+|**main**|[![Build status](https://dev.azure.com/projfs/ci/_apis/build/status/PR%20-%20Build%20and%20Functional%20Test%20-%202022?branchName=main)](https://dev.azure.com/projfs/ci/_build/latest?definitionId=7)|
+
 
 ## About ProjFS
 
@@ -50,17 +50,15 @@ coverage of the managed wrapper API surface.
 
 ## Building the ProjFS Managed API
 
-* Install [Visual Studio 2019 Community Edition](https://www.visualstudio.com/downloads/) version 16.4 or higher.
+* Install [Visual Studio 2022 Community Edition](https://www.visualstudio.com/downloads/).
   * Include the following workloads:
     * **.NET desktop development**
-    * **.NET Core cross-platform development**
     * **Desktop development with C++**
-  * Include the following individual components:
-    * **.NET Framework 4.6.1 SDK**
+  * Ensure the following individual components are installed:
     * **C++/CLI support**
     * **Windows 10 SDK (10.0.19041.0)**
 * Create a folder to clone into, e.g. `C:\Repos\ProjFS-Managed`
-* Clone this repo into the `src` subfolder, e.g. `C:\Repos\ProjFS-Managed\src`
+* Clone this repo into a subfolder named `src`, e.g. `C:\Repos\ProjFS-Managed\src`
 * Run `src\scripts\BuildProjFS-Managed.bat`
   * You can also build in Visual Studio by opening `src\ProjectedFSLib.Managed.sln` and building.
 

--- a/scripts/BuildProjFS-Managed.bat
+++ b/scripts/BuildProjFS-Managed.bat
@@ -45,7 +45,6 @@ call "%VsDir%\VC\Auxiliary\Build\vcvarsall.bat" x86_amd64
  
 :: Restore all dependencies and run the build.
 pushd "%PROJFS_SRCDIR%"
-%nuget% install Microsoft.NETFramework.ReferenceAssemblies.net461  -Version 1.0.2 -OutputDirectory %PROJFS_PACKAGESDIR%
 msbuild /t:Restore ProjectedFSLib.Managed.sln
 msbuild ProjectedFSLib.Managed.sln /p:ProjFSManagedVersion=%ProjFSManagedVersion% /p:Configuration=%SolutionConfiguration% /p:Platform=x64 || exit /b 1
 popd

--- a/scripts/BuildProjFS-Managed.bat
+++ b/scripts/BuildProjFS-Managed.bat
@@ -24,8 +24,8 @@ SET vswherever=2.8.4
 SET vswhere=%PROJFS_PACKAGESDIR%\vswhere.%vswherever%\tools\vswhere.exe
 set WINSDK_BUILD=19041
 echo Checking for VS installation:
-echo %vswhere% -all -prerelease -latest -version "[16.4,17.0)" -products * -requires Microsoft.Component.MSBuild Microsoft.VisualStudio.Workload.ManagedDesktop Microsoft.VisualStudio.Workload.NativeDesktop Microsoft.VisualStudio.Workload.NetCoreTools Microsoft.VisualStudio.Component.Windows10SDK.%WINSDK_BUILD% Microsoft.VisualStudio.Component.VC.CLI.Support -property installationPath
-for /f "usebackq tokens=*" %%i in (`%vswhere% -all -prerelease -latest -version "[16.4,17.0)" -products * -requires Microsoft.Component.MSBuild Microsoft.VisualStudio.Workload.ManagedDesktop Microsoft.VisualStudio.Workload.NativeDesktop Microsoft.VisualStudio.Workload.NetCoreTools Microsoft.VisualStudio.Component.Windows10SDK.%WINSDK_BUILD% Microsoft.VisualStudio.Component.VC.CLI.Support -property installationPath`) do (
+echo %vswhere% -all -prerelease -latest -version "[16.4,17.1)" -products * -requires Microsoft.Component.MSBuild Microsoft.VisualStudio.Workload.ManagedDesktop Microsoft.VisualStudio.Workload.NativeDesktop Microsoft.VisualStudio.Component.Windows10SDK.%WINSDK_BUILD% Microsoft.VisualStudio.Component.VC.CLI.Support -property installationPath
+for /f "usebackq tokens=*" %%i in (`%vswhere% -all -prerelease -latest -version "[16.4,17.1)" -products * -requires Microsoft.Component.MSBuild Microsoft.VisualStudio.Workload.ManagedDesktop Microsoft.VisualStudio.Workload.NativeDesktop Microsoft.VisualStudio.Component.Windows10SDK.%WINSDK_BUILD% Microsoft.VisualStudio.Component.VC.CLI.Support -property installationPath`) do (
   set VsDir=%%i
 )
 

--- a/scripts/BuildProjFS-Managed.bat
+++ b/scripts/BuildProjFS-Managed.bat
@@ -24,8 +24,8 @@ SET vswherever=2.8.4
 SET vswhere=%PROJFS_PACKAGESDIR%\vswhere.%vswherever%\tools\vswhere.exe
 set WINSDK_BUILD=19041
 echo Checking for VS installation:
-echo %vswhere% -all -prerelease -latest -version "[16.4,17.1)" -products * -requires Microsoft.Component.MSBuild Microsoft.VisualStudio.Workload.ManagedDesktop Microsoft.VisualStudio.Workload.NativeDesktop Microsoft.VisualStudio.Component.Windows10SDK.%WINSDK_BUILD% Microsoft.VisualStudio.Component.VC.CLI.Support -property installationPath
-for /f "usebackq tokens=*" %%i in (`%vswhere% -all -prerelease -latest -version "[16.4,17.1)" -products * -requires Microsoft.Component.MSBuild Microsoft.VisualStudio.Workload.ManagedDesktop Microsoft.VisualStudio.Workload.NativeDesktop Microsoft.VisualStudio.Component.Windows10SDK.%WINSDK_BUILD% Microsoft.VisualStudio.Component.VC.CLI.Support -property installationPath`) do (
+echo %vswhere% -all -prerelease -latest -version "[16.4,18.0)" -products * -requires Microsoft.Component.MSBuild Microsoft.VisualStudio.Workload.ManagedDesktop Microsoft.VisualStudio.Workload.NativeDesktop Microsoft.VisualStudio.Component.Windows10SDK.%WINSDK_BUILD% Microsoft.VisualStudio.Component.VC.CLI.Support -property installationPath
+for /f "usebackq tokens=*" %%i in (`%vswhere% -all -prerelease -latest -version "[16.4,18.0)" -products * -requires Microsoft.Component.MSBuild Microsoft.VisualStudio.Workload.ManagedDesktop Microsoft.VisualStudio.Workload.NativeDesktop Microsoft.VisualStudio.Component.Windows10SDK.%WINSDK_BUILD% Microsoft.VisualStudio.Component.VC.CLI.Support -property installationPath`) do (
   set VsDir=%%i
 )
 

--- a/scripts/BuildProjFS-Managed.bat
+++ b/scripts/BuildProjFS-Managed.bat
@@ -45,6 +45,7 @@ call "%VsDir%\VC\Auxiliary\Build\vcvarsall.bat" x86_amd64
  
 :: Restore all dependencies and run the build.
 pushd "%PROJFS_SRCDIR%"
+%nuget% install Microsoft.NETFramework.ReferenceAssemblies.net461  -Version 1.0.2 -OutputDirectory %PROJFS_PACKAGESDIR%
 msbuild /t:Restore ProjectedFSLib.Managed.sln
 msbuild ProjectedFSLib.Managed.sln /p:ProjFSManagedVersion=%ProjFSManagedVersion% /p:Configuration=%SolutionConfiguration% /p:Platform=x64 || exit /b 1
 popd

--- a/simpleProviderManaged/SimpleProviderManaged.csproj
+++ b/simpleProviderManaged/SimpleProviderManaged.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="Serilog" Version="2.9.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
     <PackageReference Include="Serilog.Sinks.File" Version="4.1.0" />
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net461" Version="1.0.2" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fixes #77. This change is combined from @cgallred's and mine changes and based on[ this run](https://dev.azure.com/projfs/ci/_build/results?buildId=168&view=logs&j=cfa20e98-6997-523c-4233-f0a7302c929f) Christian triggered with them, it might be enough changes to use Windows 2022 (Please ignore the test failures - these are related to the symlink branch and are not present in the baseline)

Changelog:
 - Props file updated to reference correct Windows SDK versions
 - Targeting nugets used to build 4.6.1 on windows-2022 env (which only has .NET Core and .NET 4.8 present)
 - Redundant components removed from the vswhere check
 - Version limits updated in the vswhere check