### PR TITLE
Fix directory enumeration callback in Simple provider

### DIFF
--- a/simpleProviderManaged/ActiveEnumeration.cs
+++ b/simpleProviderManaged/ActiveEnumeration.cs
@@ -20,11 +20,6 @@ namespace SimpleProviderManaged
         }
 
         /// <summary>
-        /// Indicates whether the current item is the first one in the enumeration.
-        /// </summary>
-        public bool IsCurrentFirst { get; private set; }
-
-        /// <summary>
         /// true if Current refers to an element in the enumeration, false if Current is past the end of the collection
         /// </summary>
         public bool IsCurrentValid { get; private set; }
@@ -59,8 +54,7 @@ namespace SimpleProviderManaged
         public bool MoveNext()
         {
             this.IsCurrentValid = this.fileInfoEnumerator.MoveNext();
-            this.IsCurrentFirst = false;
-
+        
             while (this.IsCurrentValid && this.IsCurrentHidden())
             {
                 this.IsCurrentValid = this.fileInfoEnumerator.MoveNext();
@@ -146,7 +140,6 @@ namespace SimpleProviderManaged
         private void ResetEnumerator()
         {
             this.fileInfoEnumerator = this.fileInfos.GetEnumerator();
-            this.IsCurrentFirst = true;
         }
     }
 }

--- a/simpleProviderManaged/Program.cs
+++ b/simpleProviderManaged/Program.cs
@@ -20,17 +20,35 @@ namespace SimpleProviderManaged
         {
             try
             {
-                // We want verbose logging so we can see all our callback invocations.
-                Log.Logger = new LoggerConfiguration()
-                    .WriteTo.Console()
-                    .WriteTo.File("SimpleProviderManaged-.log", rollingInterval: RollingInterval.Day)
-                    .CreateLogger();
-
-                Log.Information("Start");
-
-                var parserResult = Parser.Default
+                var parser = new Parser(with =>
+                    {
+                        with.AutoHelp = true;
+                        with.AutoVersion = true;
+                        with.EnableDashDash = true;
+                        with.CaseSensitive = false;
+                        with.CaseInsensitiveEnumValues = true;
+                        with.HelpWriter = Console.Out;
+                    });
+                    
+                var parserResult = parser
                     .ParseArguments<ProviderOptions>(args)
-                    .WithParsed((ProviderOptions options) => Run(options));
+                    .WithParsed((ProviderOptions options) =>
+                    {
+                        // We want verbose logging so we can see all our callback invocations.
+                        var logConfig = new LoggerConfiguration()
+                           .WriteTo.Console()
+                           .WriteTo.File("SimpleProviderManaged-.log", rollingInterval: RollingInterval.Day);
+
+                        if (options.Verbose)
+                        {
+                            logConfig = logConfig.MinimumLevel.Verbose();
+                        }
+
+                        Log.Logger = logConfig.CreateLogger();
+
+                        Log.Information("Start");
+                        Run(options);
+                    });
 
                 Log.Information("Exit successfully");
                 return (int) ReturnCode.Success;

--- a/simpleProviderManaged/ProviderOptions.cs
+++ b/simpleProviderManaged/ProviderOptions.cs
@@ -21,6 +21,9 @@ namespace SimpleProviderManaged
         [Option('n', "notifications", HelpText = "Enable file system operation notifications.")]
         public bool EnableNotifications { get; set; }
 
+        [Option('v', "verbose", HelpText = "Use verbose log level.")]
+        public bool Verbose { get; set; }
+
         [Option('d', "denyDeletes", HelpText = "Deny deletes.", Hidden = true)]
         public bool DenyDeletes { get; set; }
 


### PR DESCRIPTION
Fix directory enumeration callback by properly following the documentation:

https://docs.microsoft.com/en-us/windows/win32/api/projectedfslib/nc-projectedfslib-prj_get_directory_enumeration_cb#return-value
