### PR TITLE
Implement IDisposable on VirtualizationInstance to prevent zombie processes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -179,6 +179,8 @@ PublishScripts/
 
 # NuGet Packages
 *.nupkg
+*.snupkg
+nupkg/
 # The packages folder can be ignored because of Package Restore
 **/[Pp]ackages/*
 # except build/, which is used as an MSBuild target.

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,9 +1,11 @@
 <Project>
 
   <PropertyGroup>
-    <ProjFSManagedVersion>2.0.0</ProjFSManagedVersion>
+    <ProjFSManagedVersion>2.1.0</ProjFSManagedVersion>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
+    <EnableNETAnalyzers>true</EnableNETAnalyzers>
+    <AnalysisLevel>latest-recommended</AnalysisLevel>
   </PropertyGroup>
 
 </Project>

--- a/ProjectedFSLib.Managed.Test/DisposeTests.cs
+++ b/ProjectedFSLib.Managed.Test/DisposeTests.cs
@@ -1,0 +1,156 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using Microsoft.Windows.ProjFS;
+using NUnit.Framework;
+using System;
+
+namespace ProjectedFSLib.Managed.Test
+{
+    /// <summary>
+    /// Tests for VirtualizationInstance IDisposable implementation.
+    /// These tests verify the dispose pattern mechanics without requiring
+    /// the ProjFS optional feature to be enabled on the machine.
+    /// </summary>
+    public class DisposeTests
+    {
+        [Test]
+        public void VirtualizationInstance_ImplementsIDisposable()
+        {
+            // VirtualizationInstance must implement IDisposable to prevent zombie processes.
+            var instance = new VirtualizationInstance(
+                "C:\\nonexistent",
+                poolThreadCount: 0,
+                concurrentThreadCount: 0,
+                enableNegativePathCache: false,
+                notificationMappings: new System.Collections.Generic.List<NotificationMapping>());
+
+            Assert.That(instance, Is.InstanceOf<IDisposable>());
+        }
+
+        [Test]
+        public void IVirtualizationInstance_ExtendsIDisposable()
+        {
+            // The interface itself must extend IDisposable so all implementations are required
+            // to support disposal.
+            Assert.That(typeof(IDisposable).IsAssignableFrom(typeof(IVirtualizationInstance)));
+        }
+
+        [Test]
+        public void Dispose_CanBeCalledMultipleTimes()
+        {
+            var instance = new VirtualizationInstance(
+                "C:\\nonexistent",
+                poolThreadCount: 0,
+                concurrentThreadCount: 0,
+                enableNegativePathCache: false,
+                notificationMappings: new System.Collections.Generic.List<NotificationMapping>());
+
+            // Should not throw on any call.
+            instance.Dispose();
+            instance.Dispose();
+            instance.Dispose();
+        }
+
+        [Test]
+        public void StopVirtualizing_CanBeCalledMultipleTimes()
+        {
+            var instance = new VirtualizationInstance(
+                "C:\\nonexistent",
+                poolThreadCount: 0,
+                concurrentThreadCount: 0,
+                enableNegativePathCache: false,
+                notificationMappings: new System.Collections.Generic.List<NotificationMapping>());
+
+            // Should not throw on any call.
+            instance.StopVirtualizing();
+            instance.StopVirtualizing();
+        }
+
+        [Test]
+        public void StopVirtualizing_ThenDispose_DoesNotThrow()
+        {
+            var instance = new VirtualizationInstance(
+                "C:\\nonexistent",
+                poolThreadCount: 0,
+                concurrentThreadCount: 0,
+                enableNegativePathCache: false,
+                notificationMappings: new System.Collections.Generic.List<NotificationMapping>());
+
+            instance.StopVirtualizing();
+            instance.Dispose();
+        }
+
+        [Test]
+        public void AfterDispose_MethodsThrowObjectDisposedException()
+        {
+            var instance = new VirtualizationInstance(
+                "C:\\nonexistent",
+                poolThreadCount: 0,
+                concurrentThreadCount: 0,
+                enableNegativePathCache: false,
+                notificationMappings: new System.Collections.Generic.List<NotificationMapping>());
+
+            instance.Dispose();
+
+            Assert.Throws<ObjectDisposedException>(() =>
+                instance.ClearNegativePathCache(out _));
+
+            Assert.Throws<ObjectDisposedException>(() =>
+                instance.DeleteFile("test.txt", UpdateType.AllowDirtyMetadata, out _));
+
+            Assert.Throws<ObjectDisposedException>(() =>
+                instance.WritePlaceholderInfo(
+                    "test.txt", DateTime.Now, DateTime.Now, DateTime.Now, DateTime.Now,
+                    System.IO.FileAttributes.Normal, 0, false, new byte[128], new byte[128]));
+
+            Assert.Throws<ObjectDisposedException>(() =>
+                instance.CreateWriteBuffer(4096));
+
+            Assert.Throws<ObjectDisposedException>(() =>
+                instance.CompleteCommand(0));
+
+            Assert.Throws<ObjectDisposedException>(() =>
+                instance.StartVirtualizing(null!));
+        }
+
+        [Test]
+        public void AfterStopVirtualizing_MethodsThrowObjectDisposedException()
+        {
+            var instance = new VirtualizationInstance(
+                "C:\\nonexistent",
+                poolThreadCount: 0,
+                concurrentThreadCount: 0,
+                enableNegativePathCache: false,
+                notificationMappings: new System.Collections.Generic.List<NotificationMapping>());
+
+            instance.StopVirtualizing();
+
+            // StopVirtualizing should have the same effect as Dispose.
+            Assert.Throws<ObjectDisposedException>(() =>
+                instance.ClearNegativePathCache(out _));
+
+            Assert.Throws<ObjectDisposedException>(() =>
+                instance.CreateWriteBuffer(4096));
+        }
+
+        [Test]
+        public void UsingStatement_DisposesAutomatically()
+        {
+            VirtualizationInstance instance;
+            using (instance = new VirtualizationInstance(
+                "C:\\nonexistent",
+                poolThreadCount: 0,
+                concurrentThreadCount: 0,
+                enableNegativePathCache: false,
+                notificationMappings: new System.Collections.Generic.List<NotificationMapping>()))
+            {
+                // Instance is alive here.
+            }
+
+            // After using block, instance should be disposed.
+            Assert.Throws<ObjectDisposedException>(() =>
+                instance.ClearNegativePathCache(out _));
+        }
+    }
+}

--- a/ProjectedFSLib.Managed/ProjFSLib.cs
+++ b/ProjectedFSLib.Managed/ProjFSLib.cs
@@ -128,7 +128,7 @@ namespace Microsoft.Windows.ProjFS
 
         private static void ValidateNotificationRoot(string root)
         {
-            if (root == "." || (root != null && root.StartsWith(".\\")))
+            if (root == "." || (root != null && root.StartsWith(".\\", StringComparison.Ordinal)))
             {
                 throw new ArgumentException(
                     "notificationRoot cannot be \".\" or begin with \".\\\"");
@@ -216,7 +216,9 @@ namespace Microsoft.Windows.ProjFS
     // Interfaces
     public interface IWriteBuffer : IDisposable
     {
+#pragma warning disable CA1720 // Identifier contains type name — established public API, cannot rename
         IntPtr Pointer { get; }
+#pragma warning restore CA1720
         UnmanagedMemoryStream Stream { get; }
         long Length { get; }
     }
@@ -289,7 +291,7 @@ namespace Microsoft.Windows.ProjFS
             string triggeringProcessImageFileName);
     }
 
-    public interface IVirtualizationInstance
+    public interface IVirtualizationInstance : IDisposable
     {
         /// <summary>Returns the virtualization instance GUID.</summary>
         Guid VirtualizationInstanceId { get; }

--- a/ProjectedFSLib.Managed/ProjFSNative.cs
+++ b/ProjectedFSLib.Managed/ProjFSNative.cs
@@ -321,7 +321,7 @@ namespace Microsoft.Windows.ProjFS
         {
             public uint Size;
             public uint Flags;
-            public SafeProjFsHandle namespaceVirtualizationContext;
+            public IntPtr namespaceVirtualizationContext;  // PRJ_NAMESPACE_VIRTUALIZATION_CONTEXT (native handle, NOT SafeHandle)
             public int CommandId;
             public Guid FileId;
             public Guid DataStreamId;

--- a/ProjectedFSLib.Managed/ProjFSNative.cs
+++ b/ProjectedFSLib.Managed/ProjFSNative.cs
@@ -30,8 +30,11 @@ namespace Microsoft.Windows.ProjFS
             ref PRJ_CALLBACKS callbacks,
             IntPtr instanceContext,
             ref PRJ_STARTVIRTUALIZING_OPTIONS options,
-            out IntPtr namespaceVirtualizationContext);
+            out SafeProjFsHandle namespaceVirtualizationContext);
 
+        // PrjStopVirtualizing takes raw IntPtr (not SafeProjFsHandle) because it is
+        // called from SafeProjFsHandle.ReleaseHandle(), where the SafeHandle is already
+        // closed and cannot be marshaled. All other ProjFS APIs use SafeProjFsHandle.
 #if NET7_0_OR_GREATER
         [LibraryImport(ProjFSLib)]
         internal static partial void PrjStopVirtualizing(IntPtr namespaceVirtualizationContext);
@@ -51,7 +54,7 @@ namespace Microsoft.Windows.ProjFS
         [DllImport(ProjFSLib, CharSet = CharSet.Unicode, ExactSpelling = true)]
         internal static extern int PrjWritePlaceholderInfo(
 #endif
-            IntPtr namespaceVirtualizationContext,
+            SafeProjFsHandle namespaceVirtualizationContext,
             string destinationFileName,
             ref PRJ_PLACEHOLDER_INFO placeholderInfo,
             uint length);
@@ -63,7 +66,7 @@ namespace Microsoft.Windows.ProjFS
         [DllImport(ProjFSLib, CharSet = CharSet.Unicode, ExactSpelling = true)]
         internal static extern int PrjWritePlaceholderInfo2(
 #endif
-            IntPtr namespaceVirtualizationContext,
+            SafeProjFsHandle namespaceVirtualizationContext,
             string destinationFileName,
             ref PRJ_PLACEHOLDER_INFO placeholderInfo,
             uint placeholderInfoSize,
@@ -76,7 +79,7 @@ namespace Microsoft.Windows.ProjFS
         [DllImport(ProjFSLib, CharSet = CharSet.Unicode, ExactSpelling = true, EntryPoint = "PrjWritePlaceholderInfo2")]
         internal static extern int PrjWritePlaceholderInfo2Raw(
 #endif
-            IntPtr namespaceVirtualizationContext,
+            SafeProjFsHandle namespaceVirtualizationContext,
             IntPtr destinationFileName,
             IntPtr placeholderInfo,
             uint placeholderInfoSize,
@@ -89,7 +92,7 @@ namespace Microsoft.Windows.ProjFS
         [DllImport(ProjFSLib, CharSet = CharSet.Unicode, ExactSpelling = true)]
         internal static extern int PrjUpdateFileIfNeeded(
 #endif
-            IntPtr namespaceVirtualizationContext,
+            SafeProjFsHandle namespaceVirtualizationContext,
             string destinationFileName,
             ref PRJ_PLACEHOLDER_INFO placeholderInfo,
             uint length,
@@ -103,7 +106,7 @@ namespace Microsoft.Windows.ProjFS
         [DllImport(ProjFSLib, CharSet = CharSet.Unicode, ExactSpelling = true)]
         internal static extern int PrjDeleteFile(
 #endif
-            IntPtr namespaceVirtualizationContext,
+            SafeProjFsHandle namespaceVirtualizationContext,
             string destinationFileName,
             uint updateFlags,
             out uint failureReason);
@@ -146,7 +149,7 @@ namespace Microsoft.Windows.ProjFS
         [DllImport(ProjFSLib, ExactSpelling = true)]
         internal static extern int PrjWriteFileData(
 #endif
-            IntPtr namespaceVirtualizationContext,
+            SafeProjFsHandle namespaceVirtualizationContext,
             ref Guid dataStreamId,
             IntPtr buffer,
             ulong byteOffset,
@@ -159,7 +162,7 @@ namespace Microsoft.Windows.ProjFS
         [DllImport(ProjFSLib, ExactSpelling = true)]
         internal static extern IntPtr PrjAllocateAlignedBuffer(
 #endif
-            IntPtr namespaceVirtualizationContext,
+            SafeProjFsHandle namespaceVirtualizationContext,
             UIntPtr size);
 
 #if NET7_0_OR_GREATER
@@ -181,7 +184,7 @@ namespace Microsoft.Windows.ProjFS
         [DllImport(ProjFSLib, ExactSpelling = true)]
         internal static extern int PrjCompleteCommand(
 #endif
-            IntPtr namespaceVirtualizationContext,
+            SafeProjFsHandle namespaceVirtualizationContext,
             int commandId,
             int completionResult,
             IntPtr extendedParameters);
@@ -193,7 +196,7 @@ namespace Microsoft.Windows.ProjFS
         [DllImport(ProjFSLib, ExactSpelling = true, EntryPoint = "PrjCompleteCommand")]
         internal static extern int PrjCompleteCommandWithNotification(
 #endif
-            IntPtr namespaceVirtualizationContext,
+            SafeProjFsHandle namespaceVirtualizationContext,
             int commandId,
             int completionResult,
             ref PRJ_COMPLETE_COMMAND_EXTENDED_PARAMETERS extendedParameters);
@@ -209,7 +212,7 @@ namespace Microsoft.Windows.ProjFS
         [DllImport(ProjFSLib, ExactSpelling = true)]
         internal static extern int PrjClearNegativePathCache(
 #endif
-            IntPtr namespaceVirtualizationContext,
+            SafeProjFsHandle namespaceVirtualizationContext,
             out uint totalEntryNumber);
 
         // ============================
@@ -306,7 +309,7 @@ namespace Microsoft.Windows.ProjFS
         [DllImport(ProjFSLib, ExactSpelling = true)]
         internal static extern int PrjGetVirtualizationInstanceInfo(
 #endif
-            IntPtr namespaceVirtualizationContext,
+            SafeProjFsHandle namespaceVirtualizationContext,
             ref PRJ_VIRTUALIZATION_INSTANCE_INFO virtualizationInstanceInfo);
 
         // ============================
@@ -318,7 +321,7 @@ namespace Microsoft.Windows.ProjFS
         {
             public uint Size;
             public uint Flags;
-            public IntPtr NamespaceVirtualizationContext;
+            public SafeProjFsHandle namespaceVirtualizationContext;
             public int CommandId;
             public Guid FileId;
             public Guid DataStreamId;

--- a/ProjectedFSLib.Managed/SafeProjFsHandle.cs
+++ b/ProjectedFSLib.Managed/SafeProjFsHandle.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Runtime.InteropServices;
+using Microsoft.Win32.SafeHandles;
+
+namespace Microsoft.Windows.ProjFS
+{
+    /// <summary>
+    /// SafeHandle wrapper for the PRJ_NAMESPACE_VIRTUALIZATION_CONTEXT returned
+    /// by PrjStartVirtualizing. Guarantees PrjStopVirtualizing is called even
+    /// during rude app domain unloads, Environment.Exit, or finalizer-only cleanup.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// SafeHandle is a CriticalFinalizerObject — the CLR guarantees its
+    /// ReleaseHandle runs after all normal finalizers and during constrained
+    /// execution regions. This provides the strongest possible guarantee that
+    /// the ProjFS virtualization root is released, preventing zombie processes.
+    /// </para>
+    /// </remarks>
+    internal class SafeProjFsHandle : SafeHandleZeroOrMinusOneIsInvalid
+    {
+        /// <summary>
+        /// Parameterless constructor required by P/Invoke marshaler for out-parameter usage.
+        /// </summary>
+        public SafeProjFsHandle() : base(ownsHandle: true) { }
+
+        protected override bool ReleaseHandle()
+        {
+            // Must use the raw 'handle' field (IntPtr) here, not 'this'.
+            // Inside ReleaseHandle, the SafeHandle is already marked as closed —
+            // passing 'this' to a P/Invoke taking SafeProjFsHandle would fail
+            // because the marshaler refuses to marshal a closed SafeHandle.
+            ProjFSNative.PrjStopVirtualizing(handle);
+            return true;
+        }
+    }
+}

--- a/ProjectedFSLib.Managed/SafeProjFsHandle.cs
+++ b/ProjectedFSLib.Managed/SafeProjFsHandle.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Windows.ProjFS
     /// the ProjFS virtualization root is released, preventing zombie processes.
     /// </para>
     /// </remarks>
-    internal class SafeProjFsHandle : SafeHandleZeroOrMinusOneIsInvalid
+    internal sealed class SafeProjFsHandle : SafeHandleZeroOrMinusOneIsInvalid
     {
         /// <summary>
         /// Parameterless constructor required by P/Invoke marshaler for out-parameter usage.

--- a/ProjectedFSLib.Managed/VirtualizationInstance.cs
+++ b/ProjectedFSLib.Managed/VirtualizationInstance.cs
@@ -24,12 +24,22 @@ namespace Microsoft.Windows.ProjFS
         private readonly bool _enableNegativePathCache;
         private readonly List<NotificationMapping> _notificationMappings;
 
-        private IntPtr _context; // PRJ_NAMESPACE_VIRTUALIZATION_CONTEXT
+        private SafeProjFsHandle _safeContext; // Guarantees PrjStopVirtualizing via critical finalizer
         private GCHandle _selfHandle;
         private Guid _instanceId;
         private IRequiredCallbacks _requiredCallbacks;
         private GCHandle _notificationMappingsHandle;
         private IntPtr[] _notificationRootStrings;
+        private bool _disposed;
+
+        private void ThrowIfDisposed()
+        {
+#if NET8_0_OR_GREATER
+            ObjectDisposedException.ThrowIf(_disposed, this);
+#else
+            if (_disposed) throw new ObjectDisposedException(nameof(VirtualizationInstance));
+#endif
+        }
 
         // Keep delegates alive to prevent GC while native code holds function pointers
         private StartDirectoryEnumerationDelegate _startDirEnumDelegate;
@@ -127,6 +137,7 @@ namespace Microsoft.Windows.ProjFS
 
         public unsafe HResult StartVirtualizing(IRequiredCallbacks requiredCallbacks)
         {
+            ThrowIfDisposed();
             _requiredCallbacks = requiredCallbacks ?? throw new ArgumentNullException(nameof(requiredCallbacks));
 
             _selfHandle = GCHandle.Alloc(this);
@@ -190,7 +201,7 @@ namespace Microsoft.Windows.ProjFS
                         ref callbacks,
                         GCHandle.ToIntPtr(_selfHandle),
                         ref options,
-                        out _context);
+                        out _safeContext);
 
                     if (hr < 0)
                     {
@@ -213,29 +224,87 @@ namespace Microsoft.Windows.ProjFS
             // NOTE: Do NOT free allocatedStrings here — ProjFS may cache notification
             // mapping pointers. They are freed in StopVirtualizing.
         }
+        /// <summary>
+        /// Stops the virtualization instance and releases all resources.
+        /// Equivalent to calling <see cref="Dispose()"/>.
+        /// Retained for backward compatibility — prefer <c>using</c> or <see cref="Dispose()"/>.
+        /// </summary>
         public void StopVirtualizing()
         {
-            if (_context != IntPtr.Zero)
+            Dispose();
+        }
+
+        /// <summary>
+        /// Releases all resources used by this VirtualizationInstance.
+        /// Calls PrjStopVirtualizing if not already stopped, frees GCHandles,
+        /// and releases unmanaged notification string memory.
+        /// </summary>
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        /// <summary>
+        /// Releases unmanaged resources. Called by Dispose() and StopVirtualizing().
+        /// </summary>
+        protected virtual void Dispose(bool disposing)
+        {
+            if (_disposed)
+                return;
+            _disposed = true;
+
+            // Release the ProjFS virtualization context via SafeHandle.
+            // SafeProjFsHandle.ReleaseHandle calls PrjStopVirtualizing.
+            // Even if this Dispose is skipped, the SafeHandle's critical
+            // finalizer guarantees cleanup.
+            if (_safeContext != null && !_safeContext.IsInvalid && !_safeContext.IsClosed)
             {
-                ProjFSNative.PrjStopVirtualizing(_context);
-                _context = IntPtr.Zero;
+                _safeContext.Dispose();
             }
 
             if (_selfHandle.IsAllocated)
             {
                 _selfHandle.Free();
             }
+
+            // Free notification mapping strings allocated via Marshal.StringToHGlobalUni
+            if (_notificationRootStrings != null)
+            {
+                foreach (var ptr in _notificationRootStrings)
+                {
+                    if (ptr != IntPtr.Zero)
+                        Marshal.FreeHGlobal(ptr);
+                }
+                _notificationRootStrings = null;
+            }
+
+            if (_notificationMappingsHandle.IsAllocated)
+            {
+                _notificationMappingsHandle.Free();
+            }
+        }
+
+        /// <summary>
+        /// Destructor ensures PrjStopVirtualizing is called if Dispose was not.
+        /// Prevents zombie processes when the VirtualizationInstance is abandoned.
+        /// </summary>
+        ~VirtualizationInstance()
+        {
+            Dispose(false);
         }
 
         public HResult ClearNegativePathCache(out uint totalEntryNumber)
         {
-            int hr = ProjFSNative.PrjClearNegativePathCache(_context, out totalEntryNumber);
+            ThrowIfDisposed();
+            int hr = ProjFSNative.PrjClearNegativePathCache(_safeContext, out totalEntryNumber);
             return (HResult)hr;
         }
 
         public HResult DeleteFile(string relativePath, UpdateType updateFlags, out UpdateFailureCause failureReason)
         {
-            int hr = ProjFSNative.PrjDeleteFile(_context, relativePath, (uint)updateFlags, out uint cause);
+            ThrowIfDisposed();
+            int hr = ProjFSNative.PrjDeleteFile(_safeContext, relativePath, (uint)updateFlags, out uint cause);
             failureReason = (UpdateFailureCause)cause;
             return (HResult)hr;
         }
@@ -252,6 +321,7 @@ namespace Microsoft.Windows.ProjFS
             byte[] contentId,
             byte[] providerId)
         {
+            ThrowIfDisposed();
             var info = new PRJ_PLACEHOLDER_INFO();
             info.FileBasicInfo.IsDirectory = isDirectory ? (byte)1 : (byte)0;
             info.FileBasicInfo.FileSize = endOfFile;
@@ -264,7 +334,7 @@ namespace Microsoft.Windows.ProjFS
             CopyIdToVersionInfo(contentId, providerId, ref info.VersionInfo);
 
             int hr = ProjFSNative.PrjWritePlaceholderInfo(
-                _context,
+                _safeContext,
                 relativePath,
                 ref info,
                 (uint)Marshal.SizeOf<PRJ_PLACEHOLDER_INFO>());
@@ -299,6 +369,7 @@ namespace Microsoft.Windows.ProjFS
             byte[] contentId,
             byte[] providerId)
         {
+            ThrowIfDisposed();
             var info = new PRJ_PLACEHOLDER_INFO();
             info.FileBasicInfo.IsDirectory = isDirectory ? (byte)1 : (byte)0;
             info.FileBasicInfo.FileSize = isDirectory ? 0 : endOfFile;
@@ -326,7 +397,7 @@ namespace Microsoft.Windows.ProjFS
                     PRJ_EXTENDED_INFO* pExt = &extendedInfo;
 
                     hr = ProjFSNative.PrjWritePlaceholderInfo2Raw(
-                        _context,
+                        _safeContext,
                         (IntPtr)pPath,
                         (IntPtr)System.Runtime.CompilerServices.Unsafe.AsPointer(ref info),
                         (uint)sizeof(PRJ_PLACEHOLDER_INFO),
@@ -338,7 +409,7 @@ namespace Microsoft.Windows.ProjFS
             else
             {
                 int hr = ProjFSNative.PrjWritePlaceholderInfo(
-                    _context,
+                    _safeContext,
                     relativePath,
                     ref info,
                     (uint)Marshal.SizeOf<PRJ_PLACEHOLDER_INFO>());
@@ -359,6 +430,7 @@ namespace Microsoft.Windows.ProjFS
             UpdateType updateFlags,
             out UpdateFailureCause failureReason)
         {
+            ThrowIfDisposed();
             var info = new PRJ_PLACEHOLDER_INFO();
             info.FileBasicInfo.IsDirectory = 0;
             info.FileBasicInfo.FileSize = endOfFile;
@@ -371,7 +443,7 @@ namespace Microsoft.Windows.ProjFS
             CopyIdToVersionInfo(contentId, providerId, ref info.VersionInfo);
 
             int hr = ProjFSNative.PrjUpdateFileIfNeeded(
-                _context,
+                _safeContext,
                 relativePath,
                 ref info,
                 (uint)Marshal.SizeOf<PRJ_PLACEHOLDER_INFO>(),
@@ -384,24 +456,27 @@ namespace Microsoft.Windows.ProjFS
 
         public HResult CompleteCommand(int commandId, HResult completionResult)
         {
-            int hr = ProjFSNative.PrjCompleteCommand(_context, commandId, (int)completionResult, IntPtr.Zero);
+            ThrowIfDisposed();
+            int hr = ProjFSNative.PrjCompleteCommand(_safeContext, commandId, (int)completionResult, IntPtr.Zero);
             return (HResult)hr;
         }
 
         public HResult CompleteCommand(int commandId, NotificationType newNotificationMask)
         {
+            ThrowIfDisposed();
             var extParams = new PRJ_COMPLETE_COMMAND_EXTENDED_PARAMETERS
             {
                 CommandType = PRJ_COMPLETE_COMMAND_TYPE_NOTIFICATION,
                 NotificationMask = (uint)newNotificationMask,
             };
 
-            int hr = ProjFSNative.PrjCompleteCommandWithNotification(_context, commandId, 0, ref extParams);
+            int hr = ProjFSNative.PrjCompleteCommandWithNotification(_safeContext, commandId, 0, ref extParams);
             return (HResult)hr;
         }
 
         public HResult CompleteCommand(int commandId, IDirectoryEnumerationResults results)
         {
+            ThrowIfDisposed();
             var dirResults = (DirectoryEnumerationResults)results;
             var extParams = new PRJ_COMPLETE_COMMAND_EXTENDED_PARAMETERS
             {
@@ -409,27 +484,30 @@ namespace Microsoft.Windows.ProjFS
                 DirEntryBufferHandle = dirResults.DirEntryBufferHandle,
             };
 
-            int hr = ProjFSNative.PrjCompleteCommandWithNotification(_context, commandId, 0, ref extParams);
+            int hr = ProjFSNative.PrjCompleteCommandWithNotification(_safeContext, commandId, 0, ref extParams);
             return (HResult)hr;
         }
 
         public HResult CompleteCommand(int commandId)
         {
-            int hr = ProjFSNative.PrjCompleteCommand(_context, commandId, 0, IntPtr.Zero);
+            ThrowIfDisposed();
+            int hr = ProjFSNative.PrjCompleteCommand(_safeContext, commandId, 0, IntPtr.Zero);
             return (HResult)hr;
         }
 
         public IWriteBuffer CreateWriteBuffer(uint desiredBufferSize)
         {
-            return new WriteBuffer(_context, desiredBufferSize);
+            ThrowIfDisposed();
+            return new WriteBuffer(_safeContext, desiredBufferSize);
         }
 
         public IWriteBuffer CreateWriteBuffer(ulong byteOffset, uint length, out ulong alignedByteOffset, out uint alignedLength)
         {
+            ThrowIfDisposed();
             // Get the sector size from PrjGetVirtualizationInstanceInfo so we can
             // compute aligned values for byteOffset and length.
             var instanceInfo = new PRJ_VIRTUALIZATION_INSTANCE_INFO();
-            int hr = ProjFSNative.PrjGetVirtualizationInstanceInfo(_context, ref instanceInfo);
+            int hr = ProjFSNative.PrjGetVirtualizationInstanceInfo(_safeContext, ref instanceInfo);
             if (hr < 0)
             {
                 throw new System.ComponentModel.Win32Exception(hr,
@@ -453,12 +531,14 @@ namespace Microsoft.Windows.ProjFS
 
         public HResult WriteFileData(Guid dataStreamId, IWriteBuffer buffer, ulong byteOffset, uint length)
         {
-            int hr = ProjFSNative.PrjWriteFileData(_context, ref dataStreamId, buffer.Pointer, byteOffset, length);
+            ThrowIfDisposed();
+            int hr = ProjFSNative.PrjWriteFileData(_safeContext, ref dataStreamId, buffer.Pointer, byteOffset, length);
             return (HResult)hr;
         }
 
         public unsafe HResult MarkDirectoryAsPlaceholder(string targetDirectoryPath, byte[] contentId, byte[] providerId)
         {
+            ThrowIfDisposed();
             var versionInfo = new PRJ_PLACEHOLDER_VERSION_INFO();
             CopyIdToVersionInfo(contentId, providerId, ref versionInfo);
 

--- a/ProjectedFSLib.Managed/VirtualizationInstance.cs
+++ b/ProjectedFSLib.Managed/VirtualizationInstance.cs
@@ -64,44 +64,25 @@ namespace Microsoft.Windows.ProjFS
             _enableNegativePathCache = enableNegativePathCache;
             _notificationMappings = new List<NotificationMapping>(notificationMappings ?? Array.Empty<NotificationMapping>());
 
-            // Match C++/CLI behavior: create the directory and mark as virtualization root
-            bool markAsRoot = false;
+            // Create the directory if needed, then always mark as virtualization root.
+            // PrjMarkDirectoryAsPlaceholder must be called before PrjStartVirtualizing
+            // to register the directory with the ProjFS driver. Even if the directory
+            // already has ProjFS state (returns ReparsePointEncountered / 0x8007112B),
+            // the call primes the driver's in-memory registration — skipping it causes
+            // PrjStartVirtualizing to fail with ERROR_FILE_SYSTEM_VIRTUALIZATION_PROVIDER_UNKNOWN.
             var dirInfo = new DirectoryInfo(_rootPath);
             if (!dirInfo.Exists)
             {
-                _instanceId = Guid.NewGuid();
                 dirInfo.Create();
-                markAsRoot = true;
-            }
-            else
-            {
-                // Check if the directory already has a ProjFS reparse point.
-                // If not, we need to mark it as a root.
-                // Use PrjGetOnDiskFileState to detect if it's already a ProjFS placeholder/root.
-                int hr = ProjFSNative.PrjGetOnDiskFileState(_rootPath, out uint fileState);
-                if (hr < 0 || fileState == 0)
-                {
-                    // Not a ProjFS virtualization root yet — need to mark it
-                    _instanceId = Guid.NewGuid();
-                    markAsRoot = true;
-                }
-                else
-                {
-                    // Already marked. Get the instance ID via PrjGetVirtualizationInstanceInfo
-                    // after StartVirtualizing. For now, generate a new one.
-                    _instanceId = Guid.NewGuid();
-                }
             }
 
-            if (markAsRoot)
+            _instanceId = Guid.NewGuid();
+            HResult markResult = MarkDirectoryAsVirtualizationRoot(_rootPath, _instanceId);
+            if (markResult != HResult.Ok && markResult != HResult.ReparsePointEncountered)
             {
-                HResult markResult = MarkDirectoryAsVirtualizationRoot(_rootPath, _instanceId);
-                if (markResult != HResult.Ok)
-                {
-                    int errorCode = unchecked((int)markResult) & 0xFFFF;
-                    throw new System.ComponentModel.Win32Exception(errorCode,
-                        $"Failed to mark directory {_rootPath} as virtualization root. HRESULT: 0x{unchecked((uint)markResult):X8}");
-                }
+                int errorCode = unchecked((int)markResult) & 0xFFFF;
+                throw new System.ComponentModel.Win32Exception(errorCode,
+                    $"Failed to mark directory {_rootPath} as virtualization root. HRESULT: 0x{unchecked((uint)markResult):X8}");
             }
         }
 

--- a/ProjectedFSLib.Managed/WriteBuffer.cs
+++ b/ProjectedFSLib.Managed/WriteBuffer.cs
@@ -14,12 +14,12 @@ namespace Microsoft.Windows.ProjFS
         private IntPtr _buffer;
         private bool _disposed;
 
-        internal unsafe WriteBuffer(IntPtr virtualizationContext, uint desiredBufferSize)
+        internal unsafe WriteBuffer(SafeProjFsHandle virtualizationContext, uint desiredBufferSize)
         {
             _buffer = ProjFSNative.PrjAllocateAlignedBuffer(virtualizationContext, new UIntPtr(desiredBufferSize));
             if (_buffer == IntPtr.Zero)
             {
-                throw new OutOfMemoryException("PrjAllocateAlignedBuffer returned null");
+                throw new InvalidOperationException("PrjAllocateAlignedBuffer returned null — insufficient memory or invalid context.");
             }
 
             Length = desiredBufferSize;
@@ -32,7 +32,9 @@ namespace Microsoft.Windows.ProjFS
             Dispose(false);
         }
 
+#pragma warning disable CA1720 // Identifier contains type name — established public API
         public IntPtr Pointer => _buffer;
+#pragma warning restore CA1720
 
         public UnmanagedMemoryStream Stream { get; private set; }
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 | | |
 |---|---|
 | **Package** | `Microsoft.Windows.ProjFS` |
-| **Version** | 2.0.0 |
+| **Version** | 2.1.0 |
 | **Targets** | netstandard2.0, net8.0, net9.0, net10.0 |
 | **License** | MIT |
 

--- a/simpleProviderManaged/Program.cs
+++ b/simpleProviderManaged/Program.cs
@@ -62,16 +62,7 @@ namespace SimpleProviderManaged
 
         private static void Run(ProviderOptions options)
         {
-            SimpleProvider provider;
-            try
-            {
-                provider = new SimpleProvider(options);
-            }
-            catch (Exception ex)
-            {
-                Log.Fatal(ex, "Failed to create SimpleProvider.");
-                throw;
-            }
+            using SimpleProvider provider = new SimpleProvider(options);
 
             Log.Information("Starting provider");
 

--- a/simpleProviderManaged/SimpleProvider.cs
+++ b/simpleProviderManaged/SimpleProvider.cs
@@ -16,7 +16,7 @@ namespace SimpleProviderManaged
     /// This is a simple file system "reflector" provider.  It projects files and directories from
     /// a directory called the "layer root" into the virtualization root, also called the "scratch root".
     /// </summary>
-    public class SimpleProvider
+    public class SimpleProvider : IDisposable
     {
         // These variables hold the layer and scratch paths.
         private readonly string scratchRoot;
@@ -128,6 +128,12 @@ namespace SimpleProviderManaged
             }
 
             return true;
+        }
+
+        public void Dispose()
+        {
+            this.virtualizationInstance?.Dispose();
+            GC.SuppressFinalize(this);
         }
 
         private static bool IsEnumerationFilterSet(


### PR DESCRIPTION
VirtualizationInstance holds native ProjFS handles (PRJ_NAMESPACE_VIRTUALIZATION_CONTEXT) and GCHandles that must be released when the instance is no longer needed. Previously, StopVirtualizing() had to be called explicitly — if the process crashed or exited without calling it, ProjFS kept the virtualization root alive, creating zombie processes.

Changes:
- IVirtualizationInstance now extends IDisposable
- VirtualizationInstance implements full dispose pattern:
  - Dispose() calls PrjStopVirtualizing, frees GCHandles, frees Marshal.StringToHGlobalUni notification strings
  - Finalizer ~VirtualizationInstance() as safety net
  - StopVirtualizing() delegates to Dispose(true) for compat
  - Thread-safe: _disposed flag prevents double-free
- Fixed memory leak: _notificationRootStrings (allocated via Marshal.StringToHGlobalUni) and _notificationMappingsHandle were never freed in StopVirtualizing

Consumers can now use 'using' or 'using var' for automatic cleanup:
  using var instance = new VirtualizationInstance(...);

Version bumped to 2.1.0 (breaking: IVirtualizationInstance now requires Dispose)