### PR TITLE
Guard against null virtualization context: throw InvalidOperationException instead of an opaque NullReferenceException

### DIFF
--- a/ProjectedFSLib.Managed.Test/ContextGuardTests.cs
+++ b/ProjectedFSLib.Managed.Test/ContextGuardTests.cs
@@ -1,0 +1,87 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using Microsoft.Windows.ProjFS;
+using NUnit.Framework;
+using System;
+
+namespace ProjectedFSLib.Managed.Test
+{
+    /// <summary>
+    /// Tests that methods requiring a running virtualization context fail with a clear
+    /// <see cref="InvalidOperationException"/> when called before <c>StartVirtualizing</c>
+    /// has established the native context, rather than throwing an opaque
+    /// <see cref="NullReferenceException"/> from inside the P/Invoke marshaling stub.
+    ///
+    /// This guards the failure mode observed in VFS for Git telemetry, where a
+    /// <c>StartVirtualizing</c> that threw under memory pressure (before assigning the
+    /// context) left subsequent <c>CompleteCommand</c> / <c>DeleteFile</c> calls
+    /// dereferencing a null SafeHandle. The resulting crash was reported against the
+    /// native entry point (PrjCompleteCommand / PrjDeleteFile) and was indistinguishable
+    /// from a genuine native access violation.
+    ///
+    /// These tests do not require the ProjFS optional feature to be enabled.
+    /// </summary>
+    public class ContextGuardTests
+    {
+        private static VirtualizationInstance CreateInstance()
+        {
+            return new VirtualizationInstance(
+                "C:\\nonexistent",
+                poolThreadCount: 0,
+                concurrentThreadCount: 0,
+                enableNegativePathCache: false,
+                notificationMappings: new System.Collections.Generic.List<NotificationMapping>());
+        }
+
+        [Test]
+        public void BeforeStartVirtualizing_ContextMethodsThrowInvalidOperationException()
+        {
+            using var instance = CreateInstance();
+
+            // StartVirtualizing has never been called, so the native context is null.
+            // Each of these must surface a clear InvalidOperationException instead of a
+            // NullReferenceException from the marshaling stub.
+            Assert.Throws<InvalidOperationException>(() =>
+                instance.ClearNegativePathCache(out _));
+
+            Assert.Throws<InvalidOperationException>(() =>
+                instance.DeleteFile("test.txt", UpdateType.AllowDirtyMetadata, out _));
+
+            Assert.Throws<InvalidOperationException>(() =>
+                instance.WritePlaceholderInfo(
+                    "test.txt", DateTime.Now, DateTime.Now, DateTime.Now, DateTime.Now,
+                    System.IO.FileAttributes.Normal, 0, false, new byte[128], new byte[128]));
+
+            Assert.Throws<InvalidOperationException>(() =>
+                instance.UpdateFileIfNeeded(
+                    "test.txt", DateTime.Now, DateTime.Now, DateTime.Now, DateTime.Now,
+                    System.IO.FileAttributes.Normal, 0, new byte[128], new byte[128],
+                    UpdateType.AllowDirtyMetadata, out _));
+
+            Assert.Throws<InvalidOperationException>(() =>
+                instance.CreateWriteBuffer(4096));
+
+            Assert.Throws<InvalidOperationException>(() =>
+                instance.CompleteCommand(0));
+
+            Assert.Throws<InvalidOperationException>(() =>
+                instance.CompleteCommand(0, HResult.Ok));
+        }
+
+        [Test]
+        public void DisposedTakesPrecedenceOverMissingContext()
+        {
+            var instance = CreateInstance();
+            instance.Dispose();
+
+            // Once disposed, the disposed check must win: callers get ObjectDisposedException,
+            // not InvalidOperationException, even though the context was never established.
+            Assert.Throws<ObjectDisposedException>(() =>
+                instance.CompleteCommand(0));
+
+            Assert.Throws<ObjectDisposedException>(() =>
+                instance.DeleteFile("test.txt", UpdateType.AllowDirtyMetadata, out _));
+        }
+    }
+}

--- a/ProjectedFSLib.Managed/VirtualizationInstance.cs
+++ b/ProjectedFSLib.Managed/VirtualizationInstance.cs
@@ -41,6 +41,26 @@ namespace Microsoft.Windows.ProjFS
 #endif
         }
 
+        // Returns the native virtualization context, guarding against use before it has been
+        // established. _safeContext is only assigned by a successful StartVirtualizing call. If
+        // StartVirtualizing was never called, or threw (for example, an OutOfMemoryException while
+        // marshaling under memory pressure) before assigning the out parameter, _safeContext is
+        // still null. Passing a null SafeHandle to a P/Invoke throws a NullReferenceException from
+        // deep inside the generated marshaling stub, which is reported against the native entry
+        // point (e.g. PrjCompleteCommand / PrjDeleteFile) and is indistinguishable from a genuine
+        // native crash. Throwing InvalidOperationException here makes the misuse explicit and
+        // recoverable for the caller.
+        private SafeProjFsHandle RequireContext()
+        {
+            if (_safeContext == null)
+            {
+                throw new InvalidOperationException(
+                    "The virtualization instance is not running. StartVirtualizing must complete successfully before calling this method.");
+            }
+
+            return _safeContext;
+        }
+
         // Keep delegates alive to prevent GC while native code holds function pointers
         private StartDirectoryEnumerationDelegate _startDirEnumDelegate;
         private EndDirectoryEnumerationDelegate _endDirEnumDelegate;
@@ -278,14 +298,14 @@ namespace Microsoft.Windows.ProjFS
         public HResult ClearNegativePathCache(out uint totalEntryNumber)
         {
             ThrowIfDisposed();
-            int hr = ProjFSNative.PrjClearNegativePathCache(_safeContext, out totalEntryNumber);
+            int hr = ProjFSNative.PrjClearNegativePathCache(RequireContext(), out totalEntryNumber);
             return (HResult)hr;
         }
 
         public HResult DeleteFile(string relativePath, UpdateType updateFlags, out UpdateFailureCause failureReason)
         {
             ThrowIfDisposed();
-            int hr = ProjFSNative.PrjDeleteFile(_safeContext, relativePath, (uint)updateFlags, out uint cause);
+            int hr = ProjFSNative.PrjDeleteFile(RequireContext(), relativePath, (uint)updateFlags, out uint cause);
             failureReason = (UpdateFailureCause)cause;
             return (HResult)hr;
         }
@@ -315,7 +335,7 @@ namespace Microsoft.Windows.ProjFS
             CopyIdToVersionInfo(contentId, providerId, ref info.VersionInfo);
 
             int hr = ProjFSNative.PrjWritePlaceholderInfo(
-                _safeContext,
+                RequireContext(),
                 relativePath,
                 ref info,
                 (uint)Marshal.SizeOf<PRJ_PLACEHOLDER_INFO>());
@@ -378,7 +398,7 @@ namespace Microsoft.Windows.ProjFS
                     PRJ_EXTENDED_INFO* pExt = &extendedInfo;
 
                     hr = ProjFSNative.PrjWritePlaceholderInfo2Raw(
-                        _safeContext,
+                        RequireContext(),
                         (IntPtr)pPath,
                         (IntPtr)System.Runtime.CompilerServices.Unsafe.AsPointer(ref info),
                         (uint)sizeof(PRJ_PLACEHOLDER_INFO),
@@ -390,7 +410,7 @@ namespace Microsoft.Windows.ProjFS
             else
             {
                 int hr = ProjFSNative.PrjWritePlaceholderInfo(
-                    _safeContext,
+                    RequireContext(),
                     relativePath,
                     ref info,
                     (uint)Marshal.SizeOf<PRJ_PLACEHOLDER_INFO>());
@@ -424,7 +444,7 @@ namespace Microsoft.Windows.ProjFS
             CopyIdToVersionInfo(contentId, providerId, ref info.VersionInfo);
 
             int hr = ProjFSNative.PrjUpdateFileIfNeeded(
-                _safeContext,
+                RequireContext(),
                 relativePath,
                 ref info,
                 (uint)Marshal.SizeOf<PRJ_PLACEHOLDER_INFO>(),
@@ -438,7 +458,7 @@ namespace Microsoft.Windows.ProjFS
         public HResult CompleteCommand(int commandId, HResult completionResult)
         {
             ThrowIfDisposed();
-            int hr = ProjFSNative.PrjCompleteCommand(_safeContext, commandId, (int)completionResult, IntPtr.Zero);
+            int hr = ProjFSNative.PrjCompleteCommand(RequireContext(), commandId, (int)completionResult, IntPtr.Zero);
             return (HResult)hr;
         }
 
@@ -451,7 +471,7 @@ namespace Microsoft.Windows.ProjFS
                 NotificationMask = (uint)newNotificationMask,
             };
 
-            int hr = ProjFSNative.PrjCompleteCommandWithNotification(_safeContext, commandId, 0, ref extParams);
+            int hr = ProjFSNative.PrjCompleteCommandWithNotification(RequireContext(), commandId, 0, ref extParams);
             return (HResult)hr;
         }
 
@@ -465,21 +485,21 @@ namespace Microsoft.Windows.ProjFS
                 DirEntryBufferHandle = dirResults.DirEntryBufferHandle,
             };
 
-            int hr = ProjFSNative.PrjCompleteCommandWithNotification(_safeContext, commandId, 0, ref extParams);
+            int hr = ProjFSNative.PrjCompleteCommandWithNotification(RequireContext(), commandId, 0, ref extParams);
             return (HResult)hr;
         }
 
         public HResult CompleteCommand(int commandId)
         {
             ThrowIfDisposed();
-            int hr = ProjFSNative.PrjCompleteCommand(_safeContext, commandId, 0, IntPtr.Zero);
+            int hr = ProjFSNative.PrjCompleteCommand(RequireContext(), commandId, 0, IntPtr.Zero);
             return (HResult)hr;
         }
 
         public IWriteBuffer CreateWriteBuffer(uint desiredBufferSize)
         {
             ThrowIfDisposed();
-            return new WriteBuffer(_safeContext, desiredBufferSize);
+            return new WriteBuffer(RequireContext(), desiredBufferSize);
         }
 
         public IWriteBuffer CreateWriteBuffer(ulong byteOffset, uint length, out ulong alignedByteOffset, out uint alignedLength)
@@ -488,7 +508,7 @@ namespace Microsoft.Windows.ProjFS
             // Get the sector size from PrjGetVirtualizationInstanceInfo so we can
             // compute aligned values for byteOffset and length.
             var instanceInfo = new PRJ_VIRTUALIZATION_INSTANCE_INFO();
-            int hr = ProjFSNative.PrjGetVirtualizationInstanceInfo(_safeContext, ref instanceInfo);
+            int hr = ProjFSNative.PrjGetVirtualizationInstanceInfo(RequireContext(), ref instanceInfo);
             if (hr < 0)
             {
                 throw new System.ComponentModel.Win32Exception(hr,
@@ -513,7 +533,7 @@ namespace Microsoft.Windows.ProjFS
         public HResult WriteFileData(Guid dataStreamId, IWriteBuffer buffer, ulong byteOffset, uint length)
         {
             ThrowIfDisposed();
-            int hr = ProjFSNative.PrjWriteFileData(_safeContext, ref dataStreamId, buffer.Pointer, byteOffset, length);
+            int hr = ProjFSNative.PrjWriteFileData(RequireContext(), ref dataStreamId, buffer.Pointer, byteOffset, length);
             return (HResult)hr;
         }
 


### PR DESCRIPTION
## Summary

Every `VirtualizationInstance` method that calls a P/Invoke requiring a running virtualization context passes the `_safeContext` `SafeHandle` **without a null check**. `_safeContext` is only assigned by a *successful* `StartVirtualizing` call (`out _safeContext`). If `StartVirtualizing` was never called, or threw before that assignment completed — for example an `OutOfMemoryException` raised while marshaling under memory pressure — `_safeContext` remains `null`.

Passing a `null` `SafeHandle` to a P/Invoke throws a `NullReferenceException` from inside the generated marshaling stub. In crash telemetry that exception is attributed to the **native entry point** (e.g. `PrjCompleteCommand` / `PrjDeleteFile`) and is **indistinguishable from a genuine native access violation** inside `ProjectedFSLib.dll`. This makes the real cause — a partially-initialized instance / a `StartVirtualizing` that threw — impossible to diagnose from the dump.

## Motivation

This surfaced while investigating recurring VFS for Git (`microsoft/VFSForGit`) `GVFS.Mount` crashes whose two dominant signatures are `NullReferenceException` at `ProjFSNative.PrjCompleteCommand` and at `ProjFSNative.PrjDeleteFile`, correlated with high memory pressure. The ambiguity of "native crash vs. managed misuse" in those buckets is exactly what this guard removes.

## Change

- Add a private `RequireContext()` helper that throws a clear `InvalidOperationException` when `_safeContext` is `null`, and route every context-requiring P/Invoke through it (`ClearNegativePathCache`, `DeleteFile`, `WritePlaceholderInfo`/`WritePlaceholderInfo2`, `UpdateFileIfNeeded`, all `CompleteCommand` overloads, `CreateWriteBuffer`, `GetVirtualizationInstanceInfo`, `WriteFileData`).
- The existing `ThrowIfDisposed()` check still runs first, so a **disposed** instance continues to throw `ObjectDisposedException` (verified by a test).
- Methods that legitimately run before the context exists — `StartVirtualizing` (which assigns it) and `MarkDirectoryAsPlaceholder` (which uses `_rootPath`, not the context, and is called *before* `StartVirtualizing`) — are unchanged.

## Behavior

No change for correctly-sequenced callers. Misuse (or a failed `StartVirtualizing`) now produces an actionable `InvalidOperationException` with a clear message instead of an opaque `NullReferenceException` blamed on native code.

## Tests

Adds `ContextGuardTests`:
- `BeforeStartVirtualizing_ContextMethodsThrowInvalidOperationException` — every context method throws `InvalidOperationException` before `StartVirtualizing`.
- `DisposedTakesPrecedenceOverMissingContext` — after `Dispose`, callers still get `ObjectDisposedException`.

These follow the existing `DisposeTests` pattern and do **not** require the ProjFS optional feature to be enabled. All 10 dispose/context tests pass locally (`net10.0-windows`).

## Notes / scope

This does not (and cannot) address genuine native access violations inside `ProjectedFSLib.dll` under memory exhaustion — that is an OS-component concern and is being handled separately on the consumer side (reducing memory pressure + graceful handling in VFSForGit). This PR's value is **legibility and correctness**: it stops the managed wrapper from masquerading a missing-context bug as a native crash.

---

> Draft: opening for discussion; happy to adjust the exception type/message or fold `RequireContext()` into `ThrowIfDisposed()` semantics if preferred.

*Assisted-by: Claude Opus 4.8*
